### PR TITLE
fix card name in manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ resources:
 
 ```yaml
 resources:
-  - url: /local/simple-thermostat.js?v=1
+  - url: /local/banner-card.js?v=1
     type: module
 ```
 


### PR DESCRIPTION
Replace `simple-thermostat.js` by `banner-card.js` in Manual installation