### PR TITLE
Fixed misalignment when row_size is 3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class BannerCard extends LitElement {
     // calculate grid
     this.gridSizes = Array(this.rowSize)
       .fill(this.rowSize)
-      .map((size, index) => Math.round(((index + 1) / size) * 100));
+      .map((size, index) => Math.round((1 / size) * 100) * (index + 1));
   }
 
   set hass(hass) {


### PR DESCRIPTION
This is to fix misalignment when row_size is 3 and entity size is 2

If you have 5 entities defined, first one has size two and reset of them are size one, then this is what it looks like:
![Untitled 4](https://user-images.githubusercontent.com/1566619/62007716-ba4be680-b105-11e9-827e-8b59227a0141.png)

The divider between first and second is not aligned with 2nd row due to rounding.

With the fix in this PR, it looks like this now:
![Untitled 2](https://user-images.githubusercontent.com/1566619/62007718-c20b8b00-b105-11e9-9655-6639ca93936c.png)
