### PR TITLE
Add a custom card that handles remote entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/core": "^7.10.3",
     "@babel/register": "^7.10.3",
     "@rollup/plugin-commonjs": "^13.0.0",
+    "@ava/babel-preset-stage-4": "^4.0.0",
     "ava": "^3.9.0",
     "husky": "^4.2.5",
     "prettier": "^1.18.2",

--- a/src/customEntities/remoteControls.js
+++ b/src/customEntities/remoteControls.js
@@ -1,0 +1,68 @@
+import { LitElement, html, css } from "lit-element";
+import styles from "./remoteControlsStyles";
+
+class RemoteControls extends LitElement {
+  static get properties() {
+    return {
+      hass: {},
+      config: {}
+    };
+  }
+
+  static get styles() {
+    return [styles];
+  }
+
+  get buttons() {
+    return this.config.buttons;
+  }
+
+  get name() {
+    return this.config.name;
+  }
+
+  get icon() {
+    return this.config.icon;
+  }
+
+  get entity() {
+    return this.config.entity;
+  }
+
+  _service(domain, action, entity_id) {
+    return () => this.hass.callService(domain, action, { entity_id });
+  }
+
+  render() {
+    return html`
+      <ha-card class="remote-controls">
+        <div class="flex">
+          ${this.icon
+            ? html`
+                <div class="entity-icon">
+                  <ha-icon .icon="${this.icon}"></ha-icon>
+                </div>
+              `
+            : ""}
+          <span class="entity-name">${this.name}</span>
+        </div>
+        <div class="controls">
+          ${this.buttons.map(button => {
+            const [domain, service] = button.service.split(".", 2);
+
+            return html`
+              <ha-icon-button
+                role="button"
+                .icon="${button.icon}"
+                .title="${button.name}"
+                @click=${this._service(domain, service, this.entity)}
+              ></ha-icon-button>
+            `;
+          })}
+        </div>
+      </ha-card>
+    `;
+  }
+}
+
+window.customElements.define("remote-controls", RemoteControls);

--- a/src/customEntities/remoteControlsStyles.js
+++ b/src/customEntities/remoteControlsStyles.js
@@ -1,0 +1,61 @@
+import { css } from "lit-element";
+
+export default css`
+  :host {
+    --bc-font-size-heading: var(--banner-card-heading-size, 3em);
+    --bc-font-size-entity-value: var(--banner-card-entity-value-size, 1.5em);
+    --bc-font-size-media-title: var(--banner-card-media-title-size, 0.9em);
+    --bc-spacing: var(--banner-card-spacing, 4px);
+    --bc-button-size: var(--banner-card-button-size, 32px);
+    --bc-heading-color-dark: var(
+      --banner-card-heading-color-dark,
+      var(--primary-text-color)
+    );
+    --bc-heading-color-light: var(--banner-card-heading-color-light, #fff);
+    grid-column: span 3;
+  }
+
+  .remote-controls {
+    padding: 16px;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .controls {
+    flex: 2;
+    text-align: right;
+  }
+
+  .entity-name {
+    margin-left: 8px;
+    font-weight: 400;
+    white-space: nowrap;
+    font-size: 14px;
+  }
+
+  .entity-icon {
+    animation: fade-in 0.25s ease-out;
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    border-radius: 100%;
+    height: 40px;
+    width: 40px;
+    min-width: 40px;
+    line-height: 40px;
+    margin-right: calc(40px / 5);
+    text-align: center;
+    will-change: border-color;
+    transition: border-color 0.25s ease-out;
+  }
+
+  .flex {
+    display: flex;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    flex-direction: row;
+    align-items: center;
+  }
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import { parseEntity, getAttributeOrState, readableColor } from "./utils";
 import filterEntity from "./filterEntity";
 import { name, version } from "../package.json";
 
+import "./customEntities/remoteControls";
+
 function printVersion(version) {
   console.info(`%c${name}: ${version}`, "font-weight: bold");
 }
@@ -236,6 +238,8 @@ class BannerCard extends LitElement {
                   return this.renderDomainCover(options);
                 case "media_player":
                   return this.renderDomainMediaPlayer(options);
+                case "remote":
+                  return this.renderDomainRemote(options);
               }
             }
             return this.renderDomainDefault(options);
@@ -337,6 +341,21 @@ class BannerCard extends LitElement {
               role="button"
               @click=${this._service(domain, "media_next_track", entity)}
             ></ha-icon-button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  renderDomainRemote(config) {
+    return html`
+      <div class="entity-state" style="${this.grid(config.size || "full")}">
+        <div class="entity-value">
+          <div class="entity-padded">
+            <remote-controls
+              .hass="${this._hass}"
+              .config="${config}"
+            ></remote-controls>
           </div>
         </div>
       </div>

--- a/src/styles.js
+++ b/src/styles.js
@@ -81,6 +81,12 @@ export default css`
     flex: 0 0 calc(var(--bc-button-size) * 3);
   }
 
+  .entity-padded {
+    display: block;
+    min-width: -webkit-fill-available;
+    padding: 16px 16px 0 16px;
+  }
+
   .entity-state.expand .entity-value {
     width: 100%;
   }


### PR DESCRIPTION
Usage:

```
buttons:
  - icon: 'mdi:fan-off'
	name: Turn Off
	service: script.1594425488662
  - icon: 'mdi:fan'
	name: 28°c
	service: script.1594425585794
  - icon: 'mdi:fan-speed-1'
	name: 25°c
	service: script.1594989135793
  - icon: 'mdi:fan-speed-2'
	name: 22°c
	service: script.1594989161783
entity: remote.universal_remote
icon: 'mdi:air-conditioner'
name: A/C
```

![image](https://user-images.githubusercontent.com/4594463/87840726-d2ce8700-c8a9-11ea-883a-ac66da43369c.png)
