### PR TITLE
make heading margin templated

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "homeassistant": "0.100.0",
-  "render_readme": true
+  "render_readme": true,
+  "name": "banner-card-forked"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "homeassistant": "0.100.0",
-  "render_readme": true,
-  "name": "banner-card-forked"
+  "render_readme": true
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -5,6 +5,7 @@ export default css`
     --bc-font-size-heading: var(--banner-card-heading-size, 3em);
     --bc-font-size-entity-value: var(--banner-card-entity-value-size, 1.5em);
     --bc-font-size-media-title: var(--banner-card-media-title-size, 0.9em);
+    --bc-margin-heading: var(--banner-card-heading-margin, 1em);
     --bc-spacing: var(--banner-card-spacing, 4px);
     --bc-button-size: var(--banner-card-button-size, 32px);
     --bc-heading-color-dark: var(
@@ -35,6 +36,7 @@ export default css`
     justify-content: center;
     align-items: center;
     font-size: var(--bc-font-size-heading);
+    margin: var(--bc-margin-heading);
     font-weight: 300;
     cursor: pointer;
   }


### PR DESCRIPTION
added a template variable for the heading margin: `--banner-card-heading-margin`

I need this for my tablet wall panels so I can make the heading more compact and better proportion of margin to heading font size. Please merge soon :)