### PR TITLE
Adding the possibility to set up icons as entity names - similar to headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 yarn-error.log
 .nvmrc
 .DS_Store
+*.iml

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,19 @@ function createElement(tag, config, hass) {
 }
 
 function entityName(name, onClick = null) {
-  const nameHtml = isIcon(name)
-    ? html` <ha-icon class="name-icon" .icon="${name}"></ha-icon> `
-    : name;
+  if (!Array.isArray(name)) {
+    name = [name];
+  }
+
+  const nameHtml = name.map((fragment) => {
+    if (isIcon(fragment)) {
+      return html`
+        <ha-icon class="heading-icon" .icon="${fragment}"></ha-icon>
+      `;
+    }
+    return html` <span>${fragment}</span> `;
+  });
+
   if (onClick) {
     return html` <a class="entity-name" @click=${onClick}>${nameHtml}</a> `;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,13 @@ function createElement(tag, config, hass) {
 }
 
 function entityName(name, onClick = null) {
+  const nameHtml = isIcon(name)
+    ? html` <ha-icon class="name-icon" .icon="${name}"></ha-icon> `
+    : name;
   if (onClick) {
-    return html` <a class="entity-name" @click=${onClick}>${name}</a> `;
+    return html` <a class="entity-name" @click=${onClick}>${nameHtml}</a> `;
   }
-  return html` <span class="entity-name">${name}</span> `;
+  return html` <span class="entity-name">${nameHtml}</span> `;
 }
 
 class BannerCard extends LitElement {


### PR DESCRIPTION
In my use case, icons were much more readible than the simple text heading, so I wanted to update the behaviour.

It looks like this:
![image](https://user-images.githubusercontent.com/82749218/115137584-3b0fec00-a027-11eb-819d-942cc646233f.png)

And inside the code it looks like:
```yaml
      - type: custom:banner-card
        background: 'url("/local/pictures/views/bedroom.png") center center no-repeat, #84bf94; background-size: cover'
        heading:
          - mdi:bed-empty
          - Bedroom
        entities:
          - entity: sensor.netatmo_home_nordi_temperature
            # Here is the change
            name:
              - mdi:thermometer
              - Temperature
          - entity: sensor.netatmo_home_nordi_co2
            name: mdi:molecule-co2
          - entity: sensor.netatmo_home_nordi_humidity
            name: mdi:water-percent
          - entity: sensor.netatmo_home_nordi_noise
            name: mdi:account-music
          - entity: sensor.netatmo_home_nordi_pressure
            name: Pressure
          - entity: media_player.cookie
 ```

As you can see in the screenshot, I have tested the option to set up the simple icon, then icon + text, then simple text.