### PR TITLE
Fix ha-icon-button not displaying icons in HomeAssistant 2021.11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -338,17 +338,20 @@ class BannerCard extends LitElement {
               icon="mdi:skip-previous"
               role="button"
               @click=${this._service(domain, "media_previous_track", entity)}
-            ><ha-icon icon="mdi:skip-previous"></ha-icon></ha-icon-button>
+              ><ha-icon icon="mdi:skip-previous"></ha-icon
+            ></ha-icon-button>
             <ha-icon-button
               icon="${isPlaying ? "mdi:stop" : "mdi:play"}"
               role="button"
               @click=${this._service(domain, action, entity)}
-            ><ha-icon icon="${isPlaying ? "mdi:stop" : "mdi:play"}"></ha-icon></ha-icon-button>
+              ><ha-icon icon="${isPlaying ? "mdi:stop" : "mdi:play"}"></ha-icon
+            ></ha-icon-button>
             <ha-icon-button
               icon="mdi:skip-next"
               role="button"
               @click=${this._service(domain, "media_next_track", entity)}
-            ><ha-icon icon="mdi:skip-next"></ha-icon></ha-icon-button>
+              ><ha-icon icon="mdi:skip-next"></ha-icon
+            ></ha-icon-button>
           </div>
         </div>
       </div>
@@ -404,18 +407,21 @@ class BannerCard extends LitElement {
             icon="hass:arrow-up"
             role="button"
             @click=${this._service("cover", "open_cover", entity)}
-          ><ha-icon icon="hass:arrow-up"></ha-icon></ha-icon-button>
+            ><ha-icon ?disabled=${isopen} icon="hass:arrow-up"></ha-icon
+          ></ha-icon-button>
           <ha-icon-button
             icon="hass:stop"
             role="button"
             @click=${this._service("cover", "stop_cover", entity)}
-          ><ha-icon icon="hass:stop"></ha-icon></ha-icon-button>
+            ><ha-icon icon="hass:stop"></ha-icon
+          ></ha-icon-button>
           <ha-icon-button
             ?disabled=${isclosed}
             icon="hass:arrow-down"
             role="button"
             @click=${this._service("cover", "close_cover", entity)}
-          ><ha-icon icon="hass:arrow-down"></ha-icon></ha-icon-button>
+            ><ha-icon ?disabled=${isclosed} icon="hass:arrow-down"></ha-icon
+          ></ha-icon-button>
         </span>
       </div>
     `;

--- a/src/index.js
+++ b/src/index.js
@@ -338,17 +338,17 @@ class BannerCard extends LitElement {
               icon="mdi:skip-previous"
               role="button"
               @click=${this._service(domain, "media_previous_track", entity)}
-            ></ha-icon-button>
+            ><ha-icon icon="mdi:skip-previous"></ha-icon></ha-icon-button>
             <ha-icon-button
               icon="${isPlaying ? "mdi:stop" : "mdi:play"}"
               role="button"
               @click=${this._service(domain, action, entity)}
-            ></ha-icon-button>
+            ><ha-icon icon="${isPlaying ? "mdi:stop" : "mdi:play"}"></ha-icon></ha-icon-button>
             <ha-icon-button
               icon="mdi:skip-next"
               role="button"
               @click=${this._service(domain, "media_next_track", entity)}
-            ></ha-icon-button>
+            ><ha-icon icon="mdi:skip-next"></ha-icon></ha-icon-button>
           </div>
         </div>
       </div>
@@ -404,18 +404,18 @@ class BannerCard extends LitElement {
             icon="hass:arrow-up"
             role="button"
             @click=${this._service("cover", "open_cover", entity)}
-          ></ha-icon-button>
+          ><ha-icon icon="hass:arrow-up"></ha-icon></ha-icon-button>
           <ha-icon-button
             icon="hass:stop"
             role="button"
             @click=${this._service("cover", "stop_cover", entity)}
-          ></ha-icon-button>
+          ><ha-icon icon="hass:stop"></ha-icon></ha-icon-button>
           <ha-icon-button
             ?disabled=${isclosed}
             icon="hass:arrow-down"
             role="button"
             @click=${this._service("cover", "close_cover", entity)}
-          ></ha-icon-button>
+          ><ha-icon icon="hass:arrow-down"></ha-icon></ha-icon-button>
         </span>
       </div>
     `;

--- a/src/styles.js
+++ b/src/styles.js
@@ -130,7 +130,7 @@ export default css`
     width: 90%;
   }
 
-  .entity-value ha-icon {
+  .entity-value ha-icon:not([disabled]) {
     color: white;
   }
 


### PR DESCRIPTION
Add ha-icon to ha-icon-button to fix a breaking change from home-assistant/frontend#10521